### PR TITLE
Prevents the DM screen to be viewed by non localhost clients

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,8 +55,16 @@ app.use(session({secret: generateKey()}));
 app.get('/', function (req, res) {
     res.render('player', {dm: false, title: 'Dungeon Revealer'});
 });
+
 app.get('/dm', function (req, res) {
-    res.render('dm', {dm: true, title: 'Dungeon Revealer DM Console'});
+    /* console.log( req.headers ); */
+    if( req.headers['host'] == 'localhost:3000' ){
+    	res.render('dm', {dm: true, title: 'Dungeon Revealer DM Console'});
+    }
+    else
+    {
+        res.sendStatus(404);
+    }
 });
 
 
@@ -64,10 +72,13 @@ app.get('/map', function (req, res) {
     res.sendFile(GENERATED_IMAGE_PATH);
 });
 
+
 app.get('/dm/map', function (req, res) {
-    
-      var mapSent = false;
-      
+
+    var mapSent = false;
+
+    if( req.headers['host'] == 'localhost:3000' ){
+
       if (mostRecentRawImagePath) {
           res.sendFile(mostRecentRawImagePath);
           mapSent = true;
@@ -87,11 +98,13 @@ app.get('/dm/map', function (req, res) {
               }
           });
       }
+    }
       
-      if (!mapSent) {
-          res.sendStatus(404);
-      }
+    if (!mapSent) {
+        res.sendStatus(404);
+    }
 });
+
 
 // For DM map uploads. These are the raw images without any fog of war. 
 app.post('/upload', function (req, res) {


### PR DESCRIPTION
Hello,

First, greetings for your great job. This is exactly what i was looking for. It saves me few weekends of work :D

However i noticed that players could cheat : 
- If you type /dm on a client and press the back button, you can see the map flashing.
- If you type /dm/map on a client, you simply see the map.

This is a small fix for those cases. If a player goes there he just see : not found. DM of course can still see them.

Please have a review of the modifications and integrate them if you find them useful.

Best regards,

Cédric.