### PR TITLE
Update .travis.yml to build docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ language: node_js
 node_js:
   - "node"
 
-script:
-  - npm run eslint
-  - npm run build
+
+jobs:
+  include:
+    - stage: eslint
+      script:
+        - npm run eslint
+    - stage: build
+      script:
+        - npm run build
+    - stage: docker
+      script:
+        - docker build -t dungeon-revealer .
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,20 @@ jobs:
     - stage: docker
       script:
         - docker build -t dungeon-revealer .
+    - stage: GitHub Release
+      script: echo "Deploying to GitHub releases ..."
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        file:
+          - dungeon-revealer-linux
+          - dungeon-revealer-macos
+          - dungeon-revealer-win.exe
+        skip_cleanup: true
+        draft: true
+        on:
+          tags: true
+
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ jobs:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         file:
-          - dungeon-revealer-linux
-          - dungeon-revealer-macos
-          - dungeon-revealer-win.exe
+          - bin/dungeon-revealer-linux
+          - bin/dungeon-revealer-macos
+          - bin/dungeon-revealer-win.exe
         skip_cleanup: true
         draft: true
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ node_js:
 
 jobs:
   include:
-    - stage: eslint
+    - stage: Node
       script:
         - npm run eslint
-    - stage: build
-      script:
         - npm run build
     - stage: docker
       script:


### PR DESCRIPTION
I separated the travis ci into different stages and added a job to build a docker image. We can use travis for all the tests that pull requests need to pass since ci/dockercloud isn't responding.