### PR TITLE
chore: add travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dungeon-revealer
+# dungeon-revealer [![Build Status](https://travis-ci.org/apclary/dungeon-revealer.svg?branch=master)](https://travis-ci.org/apclary/dungeon-revealer)
 
 A web app for tabletop gaming to allow the game master to reveal areas of the game map to players.
 


### PR DESCRIPTION
was accidentally removed while rebasing in #48