### PR TITLE
Update travis with automatic deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "node"
+  - "10"
 cache: npm
 
 services:
@@ -40,7 +40,9 @@ jobs:
 
     - stage: github deploy
       install: true
-      script: echo "Deploying to GitHub releases ..."
+      script:
+        - echo "Deploying to GitHub releases ..."
+        - npm run build
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
@@ -58,7 +60,6 @@ jobs:
       script:
       - echo "Deploying to Dockerhub..."
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      - docker build -t dungeon-revealer .
+      - docker build -t $DOCKER_USERNAME/dungeon-revealer:$TRAVIS_TAG -t $DOCKER_USERNAME/dungeon-revealer:latest .
       - docker images
-      - docker tag dungeon-revealer $DOCKER_USERNAME/dungeon-revealer:$TRAVIS_TAG
       - docker push $DOCKER_USERNAME/dungeon-revealer

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,13 @@ cache: npm
 services:
   - docker
 
-# install:
-#   - npm install
-#
-# script:
-#   - npm run eslint
-#   - npm run build
-#
-# deploy:
-#   skip_cleanup: true
-#   on:
-#     tags: true
-
 stages:
   - cache
   - eslint
   - build
   - build docker image
   - name: github deploy
-    # if: branch = master AND tag IS present
+    # if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
     if: tag IS present
   - name: dockerhub deploy
     # if: branch = master AND tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ stages:
   - build
   - build docker image
   - name: github deploy
-    # if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
-    if: tag IS present
+    if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
+    # if: tag IS present
   - name: dockerhub deploy
-    # if: branch = master AND tag IS present
-    if: tag IS present
+    if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
+    # if: tag IS present
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,21 @@ jobs:
       script: true
 
     - stage: eslint
+      install: true
       script: npm run eslint
 
     - stage: build
+      install: true
       script: npm run build
 
     - stage: build docker image
+      install: true
       script:
       - docker build -t dungeon-revealer .
       - docker run --rm dungeon-revealer echo "hello"
 
     - stage: github deploy
+      install: true
       script: echo "Deploying to GitHub releases ..."
       deploy:
         provider: releases
@@ -62,6 +66,7 @@ jobs:
           tags: true
 
     - stage: dockerhub deploy
+      install: true
       script:
       - echo "Deploying to Dockerhub..."
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,70 @@ sudo: false
 language: node_js
 node_js:
   - "node"
-
-script:
-  - npm run eslint
-  - npm run build
+cache: npm
 
 services:
   - docker
+
+# install:
+#   - npm install
+#
+# script:
+#   - npm run eslint
+#   - npm run build
+#
+# deploy:
+#   skip_cleanup: true
+#   on:
+#     tags: true
+
+stages:
+  - cache
+  - eslint
+  - build
+  - build docker image
+  - name: github deploy
+    # if: branch = master AND tag IS present
+    if: tag IS present
+  - name: dockerhub deploy
+    # if: branch = master AND tag IS present
+    if: tag IS present
+
+jobs:
+  include:
+    - stage: cache
+      script: true
+
+    - stage: eslint
+      script: npm run eslint
+
+    - stage: build
+      script: npm run build
+
+    - stage: build docker image
+      script:
+      - docker build -t dungeon-revealer .
+      - docker run --rm dungeon-revealer echo "hello"
+
+    - stage: github deploy
+      script: echo "Deploying to GitHub releases ..."
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        file:
+          - bin/dungeon-revealer-linux
+          - bin/dungeon-revealer-macos
+          - bin/dungeon-revealer-win.exe
+        skip_cleanup: true
+        draft: true
+        on:
+          tags: true
+
+    - stage: dockerhub deploy
+      script:
+      - echo "Deploying to Dockerhub..."
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - docker build -t dungeon-revealer .
+      - docker images
+      - docker tag dungeon-revealer $DOCKER_USERNAME/dungeon-revealer:$TRAVIS_TAG
+      - docker push $DOCKER_USERNAME/dungeon-revealer

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ stages:
   - build
   - build docker image
   - name: github deploy
-    if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
-    # if: tag IS present
+    if: tag IS present
   - name: dockerhub deploy
-    if: branch = master AND tag IS present # Use this conditional if you want to limit the deployments to only the master branch
-    # if: tag IS present
+    if: tag IS present
 
 jobs:
   include:


### PR DESCRIPTION
Added stages to the travis build. The travis build first installs dependencies and caches them, then it runs the linter and builds, then it builds and tests a docker image. If there is a tag, it builds the binaries, deploys a draft release on Github that a maintainer can review and publish, and pushes a docker image to dockerhub with the tags latest and whatever the git tag is. You can see it in action on my [fork](https://travis-ci.com/maxb2/dungeon-revealer/builds).

For the github deployment, you need to generate a [personal access token](https://github.com/settings/tokens) and save it as the environment variable `GITHUB_OAUTH_TOKEN` in the [travis-ci](https://travis-ci.org/apclary/dungeon-revealer/settings) settings. For the dockerhub deployment, you need to store your username and password in the variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`. If we use this, you can turn of the ci at dockerhub.