### PR TITLE
Fix uploads dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+uploads

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+uploads
 
 # Compiled source #
 ###################

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,44 @@
+.idea
+uploads
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+dungeon-revealer-linux
+dungeon-revealer-macos
+build
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+node_modules
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ the case where the application has been bundled up into an executable */
 /* It would not surprise me at all if there was some weirdness with where 
 it creates the upload directory, either when run from a certain location or 
 run in a certain way (e.g. docker or node) */
-const UPLOADS_DIR = path.join(process.cwd(), "../uploads/");
+const UPLOADS_DIR = path.join(process.cwd(), "./uploads/");
 if (!fs.existsSync(UPLOADS_DIR)) {
   fs.mkdirSync(UPLOADS_DIR);
 }


### PR DESCRIPTION
Moved uploads to the app source directory. Added a .npmignore file to exclude uploads folder in builds. Fixes #46. 