### PR TITLE
Reducing docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+.git
 node_modules
 npm-debug.log
-uploads
+data/
+build/
+bin/dungeon-revealer-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ WORKDIR /usr/src/app
 # Copy app source
 COPY . .
 
-
-RUN npm set unsafe-perm true
 # Docker runs the app as root inside the container, 
 # so it needs elevated permissions.
-RUN npm install
+# Remove binaries after install since we don't need them.
+RUN npm set unsafe-perm true && npm install && rm bin/dungeon-revealer-*
 
 CMD [ "npm", "start" ]
 


### PR DESCRIPTION
I restructured things to try to reduce the docker image size. 

- Don't copy `build`,`data`,`.git`, or the binaries into the container.
- Run everything in one command to reduce the number of intermediate containers.
- Don't include the binaries built by `npm install`.