### PR TITLE
docker: change base image to node:10-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
`node:10-alpine` is much smaller than `node:10`.