### PR TITLE
Remove docker from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ node_js:
   - "10"
 cache: npm
 
-services:
-  - docker
 
 stages:
   - cache
   - eslint
   - build
-  - build docker image
   - name: github deploy
-    if: tag IS present
-  - name: dockerhub deploy
     if: tag IS present
 
 jobs:
@@ -29,12 +24,6 @@ jobs:
     - stage: build
       install: true
       script: npm run build
-
-    - stage: build docker image
-      install: true
-      script:
-      - docker build -t dungeon-revealer .
-      - docker run --rm dungeon-revealer echo "hello"
 
     - stage: github deploy
       install: true
@@ -52,12 +41,3 @@ jobs:
         draft: true
         on:
           tags: true
-
-    - stage: dockerhub deploy
-      install: true
-      script:
-      - echo "Deploying to Dockerhub..."
-      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      - docker build -t $DOCKER_USERNAME/dungeon-revealer:$TRAVIS_TAG -t $DOCKER_USERNAME/dungeon-revealer:latest .
-      - docker images
-      - docker push $DOCKER_USERNAME/dungeon-revealer


### PR DESCRIPTION
Since we set up dockerhub to build everything with the correct tags per #59, we can remove the docker build and deployment from the travis build.