### PR TITLE
Travis split archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,16 @@ jobs:
         - echo "Deploying $TRAVIS_TAG to GitHub releases ..."
         - npm run build
         - chmod +x bin/dungeon-revealer-linux bin/dungeon-revealer-macos
-        - zip "dungeon-revealer-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-*
+        - zip "dungeon-revealer-linux-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-linux README.md
+        - zip "dungeon-revealer-macos-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-macos README.md
+        - zip "dungeon-revealer-win-$TRAVIS_TAG.zip" -j bin/dungeon-revealer-win.exe README.md
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         file:
-          - "dungeon-revealer-$TRAVIS_TAG.zip"
+          - "dungeon-revealer-linux-$TRAVIS_TAG.zip"
+          - "dungeon-revealer-macos-$TRAVIS_TAG.zip"
+          - "dungeon-revealer-win-$TRAVIS_TAG.zip"
         skip_cleanup: true
         draft: true
         on:


### PR DESCRIPTION
This changes how we deploy the binaries as suggested [here](https://github.com/apclary/dungeon-revealer/pull/104#issuecomment-507015258). Binaries are packaged in their own zip based on system, e.g. `dungeon-revealer-linux-v1.2.0.zip`. I also included a copy of the readme in each zip.