### PR TITLE
feat: redesign player toolbar

### DIFF
--- a/src/dm-area/dm-map.js
+++ b/src/dm-area/dm-map.js
@@ -6,214 +6,10 @@ import { PanZoom } from "react-easy-panzoom";
 import ReactTooltip from "react-tooltip";
 import Referentiel from "referentiel";
 import { loadImage, getOptimalDimensions, ConditionalWrap } from "./../util";
-import { Toolbar } from "./toolbar";
+import { Toolbar } from "./../toolbar";
 import styled from "@emotion/styled";
 import { ObjectLayer } from "../object-layer";
-
-//
-// All icons are extracted from https://feather.netlify.com/
-//
-const DropletIcon = ({ fill, filled, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill={filled ? fill : "none"}
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" />
-  </svg>
-);
-
-const MoveIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M5 9l-3 3 3 3M9 5l3-3 3 3M15 19l-3 3-3-3M19 9l3 3-3 3M2 12h20M12 2v20" />
-  </svg>
-);
-
-const CropIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M6.13 1L6 16a2 2 0 0 0 2 2h15" />
-    <path d="M1 6.13L16 6a2 2 0 0 1 2 2v15" />
-  </svg>
-);
-
-const PenIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M12 19l7-7 3 3-7 7-3-3z" />
-    <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5zM2 2l7.586 7.586" />
-    <circle cx={11} cy={11} r={2} />
-  </svg>
-);
-
-const EyeIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-    <circle cx={12} cy={12} r={3} />
-  </svg>
-);
-
-const EyeOffIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24M1 1l22 22" />
-  </svg>
-);
-
-const MapIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M1 6v16l7-4 8 4 7-4V2l-7 4-8-4-7 4zM8 2v16M16 6v16" />
-  </svg>
-);
-
-const SendIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
-  </svg>
-);
-
-const RadioIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <circle cx={12} cy={12} r={2} />
-    <path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14" />
-  </svg>
-);
-
-const PauseIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <circle cx={12} cy={12} r={10} />
-    <path d="M10 15V9M14 15V9" />
-  </svg>
-);
-
-const CrosshairIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <circle cx={12} cy={12} r={10} />
-    <path d="M22 12h-4M6 12H2M12 6V2M12 22v-4" />
-  </svg>
-);
-
-const CircleIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <circle cx={12} cy={12} r={10} />
-  </svg>
-);
-
-const SquareIcon = ({ fill, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke={fill}
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    height={30}
-    {...props}
-  >
-    <rect x={3} y={3} width={18} height={18} rx={2} ry={2} />
-  </svg>
-);
+import * as Icons from "../feather-icons";
 
 const ShapeButton = styled.button`
   border: none;
@@ -229,37 +25,6 @@ const ShapeButton = styled.button`
     stroke: ${p => (p.isActive ? "rgba(0, 0, 0, 1)" : "hsl(211, 27%, 70%)")};
   }
 `;
-
-const IconLabel = ({ children, color = "inherit" }) => (
-  <div
-    style={{
-      fontSize: 10,
-      fontWeight: "bold",
-      color
-    }}
-  >
-    {children}
-  </div>
-);
-
-const ToolbarLogo = () => {
-  return (
-    <div
-      style={{
-        backgroundColor: "rgb(34, 60, 7, 1)",
-        paddingTop: 25,
-        paddingBottom: 15,
-        fontSize: 20,
-        fontWeight: "bold",
-        color: "rgba(255, 255, 255, 1)",
-        marginBottom: 24,
-        fontFamily: "folkard, palitino, serif"
-      }}
-    >
-      DR
-    </div>
-  );
-};
 
 const midPointBtw = (p1, p2) => {
   return {
@@ -1089,8 +854,8 @@ export const DmMap = ({
                   showMapModal();
                 }}
               >
-                <MapIcon />
-                <IconLabel>Change Map</IconLabel>
+                <Icons.MapIcon />
+                <Icons.Label>Change Map</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
             <Toolbar.Item>
@@ -1100,7 +865,7 @@ export const DmMap = ({
                   <Toolbar.Button onClick={hideMap}>{children}</Toolbar.Button>
                 )}
               >
-                <PauseIcon
+                <Icons.PauseIcon
                   style={{
                     stroke:
                       liveMapId !== null
@@ -1108,7 +873,7 @@ export const DmMap = ({
                         : "hsl(211, 27%, 70%)"
                   }}
                 />
-                <IconLabel
+                <Icons.Label
                   color={
                     liveMapId !== null
                       ? "hsl(360, 83%, 62%)"
@@ -1116,23 +881,23 @@ export const DmMap = ({
                   }
                 >
                   Stop Sharing
-                </IconLabel>
+                </Icons.Label>
               </ConditionalWrap>
             </Toolbar.Item>
             {isCurrentMapLive ? (
               <Toolbar.Item data-tooltip="Currently loaded map is live">
-                <RadioIcon style={{ stroke: "hsl(160, 51%, 49%)" }} />
-                <IconLabel color="hsl(160, 51%, 49%)">Live</IconLabel>
+                <Icons.RadioIcon style={{ stroke: "hsl(160, 51%, 49%)" }} />
+                <Icons.Label color="hsl(160, 51%, 49%)">Live</Icons.Label>
               </Toolbar.Item>
             ) : isOtherMapLive ? (
               <Toolbar.Item data-tooltip="A different map is live">
-                <RadioIcon style={{ stroke: "hsl(48, 94%, 68%)" }} />
-                <IconLabel color="hsl(48, 94%, 68%)">Live</IconLabel>
+                <Icons.RadioIcon style={{ stroke: "hsl(48, 94%, 68%)" }} />
+                <Icons.Label color="hsl(48, 94%, 68%)">Live</Icons.Label>
               </Toolbar.Item>
             ) : (
               <Toolbar.Item data-tooltip="A different map is live">
-                <RadioIcon style={{ stroke: "hsl(211, 27%, 70%)" }} />
-                <IconLabel color="hsl(211, 27%, 70%)">Not Live</IconLabel>
+                <Icons.RadioIcon style={{ stroke: "hsl(211, 27%, 70%)" }} />
+                <Icons.Label color="hsl(211, 27%, 70%)">Not Live</Icons.Label>
               </Toolbar.Item>
             )}
             <Toolbar.Item isEnabled>
@@ -1146,8 +911,8 @@ export const DmMap = ({
                   });
                 }}
               >
-                <SendIcon fill="rgba(0, 0, 0, 1)" />
-                <IconLabel>Send</IconLabel>
+                <Icons.SendIcon fill="rgba(0, 0, 0, 1)" />
+                <Icons.Label>Send</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
           </Toolbar.Group>
@@ -1166,7 +931,7 @@ export const DmMap = ({
         }}
       >
         <Toolbar>
-          <ToolbarLogo />
+          <Toolbar.Logo />
           <Toolbar.Group divider>
             <Toolbar.Item isActive={tool === "move"}>
               <Toolbar.Button
@@ -1174,8 +939,8 @@ export const DmMap = ({
                   setTool("move");
                 }}
               >
-                <MoveIcon />
-                <IconLabel>Move</IconLabel>
+                <Icons.MoveIcon />
+                <Icons.Label>Move</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
             <Toolbar.Item isActive={tool === "area"}>
@@ -1184,8 +949,8 @@ export const DmMap = ({
                   setTool("area");
                 }}
               >
-                <CropIcon />
-                <IconLabel>Select Area</IconLabel>
+                <Icons.CropIcon />
+                <Icons.Label>Select Area</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
             <Toolbar.Item isActive={tool === "brush"}>
@@ -1194,8 +959,8 @@ export const DmMap = ({
                   setTool("brush");
                 }}
               >
-                <PenIcon />
-                <IconLabel>Brush</IconLabel>
+                <Icons.PenIcon />
+                <Icons.Label>Brush</Icons.Label>
               </Toolbar.Button>
 
               {tool === "brush" ? (
@@ -1209,8 +974,8 @@ export const DmMap = ({
                           setBrushShape("round");
                         }}
                       >
-                        <CircleIcon />
-                        <IconLabel>Circle</IconLabel>
+                        <Icons.CircleIcon />
+                        <Icons.Label>Circle</Icons.Label>
                       </ShapeButton>
                     </div>
                     <div style={{ flex: 1, textAlign: "right" }}>
@@ -1220,8 +985,8 @@ export const DmMap = ({
                           setBrushShape("square");
                         }}
                       >
-                        <SquareIcon />
-                        <IconLabel>Square</IconLabel>
+                        <Icons.SquareIcon />
+                        <Icons.Label>Square</Icons.Label>
                       </ShapeButton>
                     </div>
                   </div>
@@ -1267,8 +1032,8 @@ export const DmMap = ({
                   setTool("mark");
                 }}
               >
-                <CrosshairIcon />
-                <IconLabel>Mark</IconLabel>
+                <Icons.CrosshairIcon />
+                <Icons.Label>Mark</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
           </Toolbar.Group>
@@ -1285,27 +1050,27 @@ export const DmMap = ({
               >
                 {mode === "shroud" ? (
                   <>
-                    <EyeOffIcon fill="rgba(0, 0, 0, 1)" />
-                    <IconLabel>Shroud</IconLabel>
+                    <Icons.EyeOffIcon fill="rgba(0, 0, 0, 1)" />
+                    <Icons.Label>Shroud</Icons.Label>
                   </>
                 ) : (
                   <>
-                    <EyeIcon fill="rgba(0, 0, 0, 1)" />
-                    <IconLabel>Reveal</IconLabel>
+                    <Icons.EyeIcon fill="rgba(0, 0, 0, 1)" />
+                    <Icons.Label>Reveal</Icons.Label>
                   </>
                 )}
               </Toolbar.Button>
             </Toolbar.Item>
             <Toolbar.Item isEnabled>
               <Toolbar.Button onClick={() => fillFog()}>
-                <DropletIcon filled />
-                <IconLabel>Shroud All</IconLabel>
+                <Icons.DropletIcon filled />
+                <Icons.Label>Shroud All</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
             <Toolbar.Item isEnabled>
               <Toolbar.Button onClick={() => clearFog()}>
-                <DropletIcon fill="rgba(0, 0, 0, 1)" />
-                <IconLabel>Clear All</IconLabel>
+                <Icons.DropletIcon fill="rgba(0, 0, 0, 1)" />
+                <Icons.Label>Clear All</Icons.Label>
               </Toolbar.Button>
             </Toolbar.Item>
           </Toolbar.Group>

--- a/src/feather-icons.js
+++ b/src/feather-icons.js
@@ -1,0 +1,261 @@
+//
+// All icons are extracted from https://feather.netlify.com/
+//
+import React from "react";
+import styled from "@emotion/styled/macro";
+
+export const Label = styled.div`
+  font-size: 10px;
+  font-weight: bold;
+  color: ${p => p.color || "inherit"};
+`;
+
+export const DropletIcon = ({ fill, filled, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill={filled ? fill : "none"}
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" />
+  </svg>
+);
+
+export const MoveIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M5 9l-3 3 3 3M9 5l3-3 3 3M15 19l-3 3-3-3M19 9l3 3-3 3M2 12h20M12 2v20" />
+  </svg>
+);
+
+export const CropIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M6.13 1L6 16a2 2 0 0 0 2 2h15" />
+    <path d="M1 6.13L16 6a2 2 0 0 1 2 2v15" />
+  </svg>
+);
+
+export const PenIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M12 19l7-7 3 3-7 7-3-3z" />
+    <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5zM2 2l7.586 7.586" />
+    <circle cx={11} cy={11} r={2} />
+  </svg>
+);
+
+export const EyeIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx={12} cy={12} r={3} />
+  </svg>
+);
+
+export const EyeOffIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24M1 1l22 22" />
+  </svg>
+);
+
+export const MapIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M1 6v16l7-4 8 4 7-4V2l-7 4-8-4-7 4zM8 2v16M16 6v16" />
+  </svg>
+);
+
+export const SendIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
+  </svg>
+);
+
+export const RadioIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={12} cy={12} r={2} />
+    <path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14" />
+  </svg>
+);
+
+export const PauseIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={12} cy={12} r={10} />
+    <path d="M10 15V9M14 15V9" />
+  </svg>
+);
+
+export const CrosshairIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={12} cy={12} r={10} />
+    <path d="M22 12h-4M6 12H2M12 6V2M12 22v-4" />
+  </svg>
+);
+
+export const CircleIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={12} cy={12} r={10} />
+  </svg>
+);
+
+export const SquareIcon = ({ fill, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <rect x={3} y={3} width={18} height={18} rx={2} ry={2} />
+  </svg>
+);
+
+export const Compass = ({ fill, props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={12} cy={12} r={10} />
+    <path d="M16.24 7.76l-2.12 6.36-6.36 2.12 2.12-6.36 6.36-2.12z" />
+  </svg>
+);
+
+export const ZoomOut = ({ fill, props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={11} cy={11} r={8} />
+    <path d="M21 21l-4.35-4.35M8 11h6" />
+  </svg>
+);
+
+export const ZoomIn = ({ fill, props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={fill}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    height={30}
+    {...props}
+  >
+    <circle cx={11} cy={11} r={8} />
+    <path d="M21 21l-4.35-4.35M11 8v6M8 11h6" />
+  </svg>
+);

--- a/src/player-area.js
+++ b/src/player-area.js
@@ -248,7 +248,7 @@ export const PlayerArea = () => {
   /**
    * long press event for setting a map marker
    */
-  useLongPress(ev => {
+  const longPressProps = useLongPress(ev => {
     if (!mapCanvasDimensions.current) {
       return;
     }
@@ -287,6 +287,7 @@ export const PlayerArea = () => {
           width: "100vw"
         }}
         ref={panZoomRef}
+        {...longPressProps}
       >
         <div ref={mapContainerRef}>
           <canvas

--- a/src/player-area.js
+++ b/src/player-area.js
@@ -4,6 +4,19 @@ import { PanZoom } from "react-easy-panzoom";
 import Referentiel from "referentiel";
 import { loadImage, useLongPress, getOptimalDimensions } from "./util";
 import { ObjectLayer } from "./object-layer";
+import { Toolbar } from "./toolbar";
+import styled from "@emotion/styled/macro";
+import * as Icons from "./feather-icons";
+
+const ToolbarContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  bottom: 0;
+  bottom: 12px;
+  pointer-events: none;
+`;
 
 export const PlayerArea = () => {
   const panZoomRef = useRef(null);
@@ -296,42 +309,63 @@ export const PlayerArea = () => {
         </div>
       </PanZoom>
       {!showSplashScreen ? (
-        <div id="dm-toolbar" className="toolbar-wrapper">
-          <div className="btn-toolbar">
-            <div className="btn-group">
-              <button
-                className="btn btn-default"
-                onClick={() => {
-                  centerMap();
-                }}
-              >
-                Center
-              </button>
-              <button
-                className="btn btn-default"
-                onClick={() => {
-                  if (!panZoomRef.current) {
-                    return;
-                  }
-                  panZoomRef.current.zoomIn();
-                }}
-              >
-                Zoom in
-              </button>
-              <button
-                className="btn btn-default"
-                onClick={() => {
-                  if (!panZoomRef.current) {
-                    return;
-                  }
-                  panZoomRef.current.zoomOut();
-                }}
-              >
-                Zoom out
-              </button>
-            </div>
-          </div>
-        </div>
+        <ToolbarContainer>
+          <Toolbar horizontal>
+            <Toolbar.Logo />
+            <Toolbar.Group>
+              <Toolbar.Item isActive>
+                <Toolbar.Button
+                  onClick={() => {
+                    centerMap();
+                  }}
+                >
+                  <Icons.Compass />
+                  <Icons.Label>Center Map</Icons.Label>
+                </Toolbar.Button>
+              </Toolbar.Item>
+              <Toolbar.Item isActive>
+                <Toolbar.LongPressButton
+                  onClick={() => {
+                    if (!panZoomRef.current) {
+                      return;
+                    }
+                    panZoomRef.current.zoomIn();
+                  }}
+                  onLongPress={() => {
+                    const interval = setInterval(() => {
+                      panZoomRef.current.zoomIn();
+                    }, 100);
+
+                    return () => clearInterval(interval);
+                  }}
+                >
+                  <Icons.ZoomIn />
+                  <Icons.Label>Zoom In</Icons.Label>
+                </Toolbar.LongPressButton>
+              </Toolbar.Item>
+              <Toolbar.Item isActive>
+                <Toolbar.LongPressButton
+                  onClick={() => {
+                    if (!panZoomRef.current) {
+                      return;
+                    }
+                    panZoomRef.current.zoomOut();
+                  }}
+                  onLongPress={() => {
+                    const interval = setInterval(() => {
+                      panZoomRef.current.zoomOut();
+                    }, 100);
+
+                    return () => clearInterval(interval);
+                  }}
+                >
+                  <Icons.ZoomOut />
+                  <Icons.Label>Zoom Out</Icons.Label>
+                </Toolbar.LongPressButton>
+              </Toolbar.Item>
+            </Toolbar.Group>
+          </Toolbar>
+        </ToolbarContainer>
       ) : null}
     </>
   );

--- a/src/style.css
+++ b/src/style.css
@@ -15,6 +15,7 @@ body {
   margin: 0px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  user-select: none;
 }
 
 #root {

--- a/src/style.css
+++ b/src/style.css
@@ -31,27 +31,6 @@ body {
   font-size: 150%;
 }
 
-#dm-toolbar {
-  position: fixed;
-  text-align: center;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  z-index: 100;
-}
-
-.toolbar-wrapper {
-  pointer-events: none;
-}
-
-.toolbar-wrapper > * {
-  pointer-events: all;
-}
-
-.btn-toolbar {
-  display: inline-block;
-}
-
 .splash {
   position: absolute;
   top: 0;

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -121,16 +121,13 @@ const ToolbarLogo = styled.div`
   line-height: 2;
 `;
 
-Toolbar.Logo = () => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+const Logo = () => {
   const { horizontal } = React.useContext(ToolbarContext);
   return <ToolbarLogo horizontal={horizontal}>DR</ToolbarLogo>;
 };
 
-Toolbar.Group = ({ children, style, divider, ...props }) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+const Group = ({ children, style, divider, ...props }) => {
   const { horizontal } = React.useContext(ToolbarContext);
-
   return (
     <ToolbarGroup horizontal={horizontal} divider={divider} {...props}>
       {children}
@@ -138,8 +135,7 @@ Toolbar.Group = ({ children, style, divider, ...props }) => {
   );
 };
 
-Toolbar.Item = ({ children, isActive, style, ...props }) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+const Item = ({ children, isActive, style, ...props }) => {
   const { horizontal } = React.useContext(ToolbarContext);
 
   return (
@@ -179,18 +175,24 @@ const LongPressButton = ({ onLongPress, ...props }) => {
 
   useEffect(() => {
     return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       clearTimeout(timeoutRef.current);
     };
   }, []);
 
   return (
-    <ToolboxButton {...props} onMouseUp={onMouseUp} onMouseDown={onMouseDown} />
+    <ToolboxButton
+      {...props}
+      onMouseDown={onMouseDown}
+      onTouchStart={onMouseDown}
+      onMouseUp={onMouseUp}
+      onTouchEnd={onMouseUp}
+    />
   );
 };
 
+Toolbar.Logo = Logo;
+Toolbar.Group = Group;
+Toolbar.Item = Item;
 Toolbar.Button = ToolboxButton;
-
 Toolbar.LongPressButton = LongPressButton;
-
 Toolbar.Popup = ToolbarItemPopup;

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 import styled from "@emotion/styled";
 
 const ToolbarContext = React.createContext({ horizontal: false });
@@ -15,8 +15,9 @@ const ToolbarBase = styled.div`
   align-items: ${p => (p.horizontal ? "center" : null)};
 
   > :first-of-type {
-    border-top-right-radius: 15px;
+    border-top-right-radius: ${p => (p.horizontal ? null : `15px`)};
     border-top-left-radius: 15px;
+    border-bottom-left-radius: ${p => (p.horizontal ? `15px` : null)};
   }
 `;
 
@@ -103,6 +104,29 @@ export const Toolbar = ({ children, horizontal, ...props }) => {
   );
 };
 
+const ToolbarLogo = styled.div`
+  background-color: rgb(34, 60, 7, 1);
+  padding-top: ${p => (p.horizontal ? `10px` : `25px`)};
+  padding-bottom: ${p => (p.horizontal ? null : `15px`)};
+  padding-left: ${p => (p.horizontal ? `15px` : null)};
+  padding-right: ${p => (p.horizontal ? `20px` : null)};
+  height: ${p => (p.horizontal ? `100%` : null)};
+  font-size: 20px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 1);
+  margin-bottom: ${p => (p.horizontal ? null : `24px`)};
+  font-family: folkard, palitino, serif;
+  display: ${p => (p.horizontal ? `flex` : null)};
+  align-items: ${p => (p.horizontal ? `center` : null)};
+  line-height: 2;
+`;
+
+Toolbar.Logo = () => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { horizontal } = React.useContext(ToolbarContext);
+  return <ToolbarLogo horizontal={horizontal}>DR</ToolbarLogo>;
+};
+
 Toolbar.Group = ({ children, style, divider, ...props }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { horizontal } = React.useContext(ToolbarContext);
@@ -125,6 +149,48 @@ Toolbar.Item = ({ children, isActive, style, ...props }) => {
   );
 };
 
+const LongPressButton = ({ onLongPress, ...props }) => {
+  const timeoutRef = useRef(null);
+  const releaseHandler = useRef(null);
+
+  const onMouseDown = useMemo(() => {
+    if (!onLongPress) {
+      return undefined;
+    }
+    return ev => {
+      ev.stopPropagation();
+      timeoutRef.current = setTimeout(() => {
+        releaseHandler.current = onLongPress();
+      }, 300);
+    };
+  }, [onLongPress]);
+
+  const onMouseUp = useMemo(() => {
+    if (!onLongPress) {
+      return undefined;
+    }
+    return () => {
+      if (releaseHandler.current) {
+        releaseHandler.current();
+      }
+      clearTimeout(timeoutRef.current);
+    };
+  }, [onLongPress]);
+
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return (
+    <ToolboxButton {...props} onMouseUp={onMouseUp} onMouseDown={onMouseDown} />
+  );
+};
+
 Toolbar.Button = ToolboxButton;
+
+Toolbar.LongPressButton = LongPressButton;
 
 Toolbar.Popup = ToolbarItemPopup;

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 
 /**
  * Utility for preloading an image as a promise
@@ -79,11 +79,25 @@ export const useLongPress = (callback = () => {}, ms = 300) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startLogPress]);
 
-  useEffect(() => {
-    const onMouseDown = ev => {
+  const onMouseDown = useCallback(
+    ev => {
+      ev.persist();
       currentEventRef.current = ev;
       setStartLongPress(true);
-    };
+    },
+    [setStartLongPress]
+  );
+
+  const onTouchStart = useCallback(
+    ev => {
+      ev.persist();
+      currentEventRef.current = ev;
+      setStartLongPress(true);
+    },
+    [setStartLongPress]
+  );
+
+  useEffect(() => {
     const onMouseUp = () => setStartLongPress(false);
     const onMouseMove = () => setStartLongPress(false);
     const onTouchMove = () => {
@@ -91,31 +105,27 @@ export const useLongPress = (callback = () => {}, ms = 300) => {
     };
     const onMouseLeave = () => setStartLongPress(false);
 
-    const onTouchStart = ev => {
-      ev.preventDefault();
-      currentEventRef.current = ev;
-      setStartLongPress(true);
-    };
     const onTouchEnd = () => setStartLongPress(false);
 
-    window.addEventListener("mousedown", onMouseDown);
     window.addEventListener("mouseup", onMouseUp);
     window.addEventListener("mousemove", onMouseMove);
     window.addEventListener("mouseleave", onMouseLeave);
-    document.addEventListener("touchstart", onTouchStart);
     document.addEventListener("touchmove", onTouchMove);
     document.addEventListener("touchend", onTouchEnd);
 
     return () => {
-      window.removeEventListener("mousedown", onMouseDown);
       window.removeEventListener("mouseup", onMouseUp);
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("mouseleave", onMouseLeave);
-      document.removeEventListener("touchstart", onTouchStart);
       document.removeEventListener("touchmove", onTouchMove);
       document.removeEventListener("touchend", onTouchEnd);
     };
   });
+
+  return {
+    onMouseDown,
+    onTouchStart
+  };
 };
 
 export const ConditionalWrap = ({ condition, wrap, children }) =>


### PR DESCRIPTION
adjusts the visual appearance of the player toolbar according to the dm toolbars.

<img width="2032" alt="Screenshot 2019-08-04 at 12 58 01" src="https://user-images.githubusercontent.com/14338007/62422740-88172780-b6b7-11e9-91c6-993010ab706e.png">

Additionally, when doing a long press on either the `Zoom In` or `Zoom Out` button, the map is zoomed in/out continuously until the user releases the long press.
