### PR TITLE
Rename npm run scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 
 Install dependencies:
 
-- `npm run install`
-
-Run the react development server:
-
-- `npm run start:dev` (visit `localhost:3001`)
+- `npm install`
 
 Run the backend:
 
-- `npm run start` (available on `localhost:3000`)
+- `npm run start:backend` (available on `localhost:3000`)
+
+Run the react development server:
+
+- `npm run start:frontend` (available on `localhost:3001`)

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "dungeon-revealer",
   "version": "1.2.1",
   "scripts": {
-    "start": "node ./bin/dungeon-revealer",
+    "start:backend": "node ./bin/dungeon-revealer",
     "eslint": "./node_modules/.bin/eslint --ignore-path .gitignore \"**/*.js\" \"bin/dungeon-revealer\"",
-    "start:dev": "cross-env PORT=3001 react-scripts start",
+    "start:frontend": "cross-env PORT=3001 react-scripts start",
     "build": "react-scripts build && pkg . --out-path ./bin/ --targets node10-win-x64,node10-macos-x64,node10-linux-x64",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
`npm run start` doesn't sound like running backend nor does `npm run
start:dev` suggest running frontend.